### PR TITLE
Store cigar offsets in lightweight index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "anstream"
-version = "0.6.11"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -66,10 +66,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.90"
+name = "byteorder"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cfg-if"
@@ -79,9 +85,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.0"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c21025abd42669a92efc996ef13cfb2c5c627858421ea58d5c3b331a6c134f"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -89,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.0"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458bf1f341769dfcf849846f65dffdf9146daa56bcd2a47cb4e1de9915567c99"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -101,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.0"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -136,6 +142,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -181,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -198,11 +213,10 @@ dependencies = [
  "bincode",
  "clap",
  "coitrees",
- "flate2",
+ "noodles",
  "num_cpus",
  "rayon",
  "serde",
- "xz2",
 ]
 
 [[package]]
@@ -212,23 +226,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
-name = "lzma-sys"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "noodles"
+version = "0.66.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f806040f810a3f911dd67246d9361b9e3d149e2b5ed02da43f909835b25fa26"
+dependencies = [
+ "noodles-bgzf",
+]
+
+[[package]]
+name = "noodles-bgzf"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ce62d1e012aa3793e17be1c286b8b71dad5a902a19524eb21729ed16113a9b"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "crossbeam-channel",
+ "flate2",
 ]
 
 [[package]]
@@ -242,16 +266,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -267,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -313,9 +331,9 @@ checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -345,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -360,51 +378,42 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
-
-[[package]]
-name = "xz2"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
-dependencies = [
- "lzma-sys",
-]
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,7 @@ edition = "2021"
 bincode = "1.3.3"
 clap = { version = "4.5.0", features = ["derive"] }
 coitrees = "0.4.0"
-flate2 = "1.0.28"
 num_cpus = "1.16.0"
 rayon = "1.9.0"
 serde = { version = "1.0.197", features = ["derive"] }
-xz2 = "0.1.7"
+noodles = { version = "0.66.0", features = ["bgzf"] }

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -83,7 +83,7 @@ impl QueryMetadata {
         let mut cigar_buffer = vec![0; self.cigar_bytes];
 
         // Get reader and seek start of cigar str
-        if paf_file.ends_with(".bgz") {
+        if [".gz", ".bgz"].iter().any(|e| paf_file.ends_with(e)) {
             let mut reader = bgzf::Reader::new(File::open(paf_file).unwrap());
             reader.seek_by_uncompressed_position(&paf_gzi_index.unwrap(), self.cigar_offset).unwrap();
             reader.read_exact(&mut cigar_buffer).unwrap();
@@ -120,7 +120,7 @@ pub struct Impg {
 impl Impg {
     pub fn from_paf_records(records: &[PafRecord], paf_file: &str) -> Result<Self, ParseErr> {
 
-        let paf_gzi_index: Option<bgzf::gzi::Index> = if paf_file.ends_with(".bgz") {
+        let paf_gzi_index: Option<bgzf::gzi::Index> = if [".gz", ".bgz"].iter().any(|e| paf_file.ends_with(e)) {
             let paf_gzi_file = paf_file.to_owned() + ".gzi";
             Some(bgzf::gzi::read(paf_gzi_file.clone()).expect(format!("Could not open {}", paf_gzi_file).as_str()))
         } else {
@@ -187,7 +187,7 @@ impl Impg {
 
     pub fn from_serializable(serializable: SerializableImpg) -> Self {
         let (serializable_trees, seq_index, paf_file) = serializable;
-        let paf_gzi_index: Option<bgzf::gzi::Index> = if paf_file.ends_with(".bgz") {
+        let paf_gzi_index: Option<bgzf::gzi::Index> = if [".gz", ".bgz"].iter().any(|e| paf_file.ends_with(e)) {
             let paf_gzi_file = paf_file.to_owned() + ".gzi";
             Some(bgzf::gzi::read(paf_gzi_file.clone()).expect(format!("Could not open {}", paf_gzi_file).as_str()))
         } else {

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -548,7 +548,8 @@ mod tests {
                 target_length: 200,
                 target_start: 30,
                 target_end: 40,
-                cigar: Some("10M".to_string()),
+                cigar_offset: 45,
+                cigar_bytes: 3,
                 strand: Strand::Forward,
             },
             // Add more test records as needed

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -121,7 +121,8 @@ impl Impg {
     pub fn from_paf_records(records: &[PafRecord], paf_file: &str) -> Result<Self, ParseErr> {
 
         let paf_gzi_index: Option<bgzf::gzi::Index> = if paf_file.ends_with(".bgz") {
-            Some(bgzf::gzi::read(paf_file.to_owned() + ".gzi").unwrap())
+            let paf_gzi_file = paf_file.to_owned() + ".gzi";
+            Some(bgzf::gzi::read(paf_gzi_file.clone()).expect(format!("Could not open {}", paf_gzi_file).as_str()))
         } else {
             None
         };
@@ -187,7 +188,8 @@ impl Impg {
     pub fn from_serializable(serializable: SerializableImpg) -> Self {
         let (serializable_trees, seq_index, paf_file) = serializable;
         let paf_gzi_index: Option<bgzf::gzi::Index> = if paf_file.ends_with(".bgz") {
-            Some(bgzf::gzi::read(paf_file.to_owned() + ".gzi").unwrap())
+            let paf_gzi_file = paf_file.to_owned() + ".gzi";
+            Some(bgzf::gzi::read(paf_gzi_file.clone()).expect(format!("Could not open {}", paf_gzi_file).as_str()))
         } else {
             None
         };

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -2,8 +2,6 @@ use std::collections::{HashMap, HashSet};
 use coitrees::{BasicCOITree, Interval, IntervalTree};
 use crate::paf::{PafRecord, ParseErr, Strand};
 use crate::seqidx::SequenceIndex;
-use xz2::write::XzEncoder;
-use xz2::read::XzDecoder;
 use serde::{Serialize, Deserialize};
 use std::io::{Read, SeekFrom, Seek};
 use std::fs::File;

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ fn main() -> io::Result<()> {
 
 fn load_or_generate_index(paf_file: &str, index_file: Option<&str>) -> io::Result<Impg> {
     let index_file = index_file.map(|s| s.to_string());
-    let index_file = index_file.unwrap_or_else(|| format!("{}.impg", paf_file));
+    let index_file = index_file.unwrap_or_else(|| format!("{}.impg-lazy", paf_file));
     let index_file = index_file.as_str();
     if std::path::Path::new(index_file).exists() {
         load_index(index_file)
@@ -89,7 +89,7 @@ fn generate_index(paf_file: &str, index_file: Option<&str>) -> io::Result<Impg> 
     };
     let reader = BufReader::new(reader);
     let records = paf::parse_paf(reader).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("Failed to parse PAF records: {:?}", e)))?;
-    let impg = Impg::from_paf_records(&records).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("Failed to create index: {:?}", e)))?;
+    let impg = Impg::from_paf_records(&records, paf_file).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("Failed to create index: {:?}", e)))?;
 
     if let Some(index_file) = index_file {
         let serializable = impg.to_serializable();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use std::fs::File;
 use std::io::{self, BufReader, BufWriter};
-use flate2::read::GzDecoder;
+use noodles::bgzf;
 use impg::impg::{Impg, SerializableImpg, QueryInterval};
 use coitrees::IntervalTree;
 use impg::paf;
@@ -82,8 +82,8 @@ fn load_or_generate_index(paf_file: &str, index_file: Option<&str>) -> io::Resul
 
 fn generate_index(paf_file: &str, index_file: Option<&str>) -> io::Result<Impg> {
     let file = File::open(paf_file)?;
-    let reader: Box<dyn io::Read> = if paf_file.ends_with(".gz") {
-        Box::new(GzDecoder::new(file))
+    let reader: Box<dyn io::Read> = if paf_file.ends_with(".bgz") {
+        Box::new(bgzf::Reader::new(file))
     } else {
         Box::new(file)
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use std::fs::File;
 use std::io::{self, BufReader, BufWriter};
+use std::num::NonZeroUsize;
 use noodles::bgzf;
 use impg::impg::{Impg, SerializableImpg, QueryInterval};
 use coitrees::IntervalTree;
@@ -36,15 +37,15 @@ struct Args {
     stats: bool,
 
     /// Number of threads for parallel processing.
-    #[clap(short='t', long, value_parser, default_value_t = num_cpus::get())]
-    num_threads: usize,
+    #[clap(short='t', long, value_parser, default_value_t = NonZeroUsize::new(1).unwrap())]
+    num_threads: NonZeroUsize,
 }
 
 fn main() -> io::Result<()> {
     let args = Args::parse();
 
     // Configure the global thread pool to use the specified number of threads
-    ThreadPoolBuilder::new().num_threads(args.num_threads).build_global().unwrap();
+    ThreadPoolBuilder::new().num_threads(args.num_threads.into()).build_global().unwrap();
 
     let impg = match args {
         Args { paf_file: Some(paf), index_file: None, force_reindex: false, .. } => load_or_generate_index(&paf, None)?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,7 @@ fn load_or_generate_index(paf_file: &str, index_file: Option<&str>, num_threads:
 
 fn generate_index(paf_file: &str, index_file: Option<&str>, num_threads: NonZeroUsize) -> io::Result<Impg> {
     let file = File::open(paf_file)?;
-    let reader: Box<dyn io::Read> = if paf_file.ends_with(".bgz") {
+    let reader: Box<dyn io::Read> = if [".gz", ".bgz"].iter().any(|e| paf_file.ends_with(e)) {
         Box::new(bgzf::MultithreadedReader::with_worker_count(num_threads, file))
     } else {
         Box::new(file)

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ fn main() -> io::Result<()> {
 
 fn load_or_generate_index(paf_file: &str, index_file: Option<&str>, num_threads: NonZeroUsize) -> io::Result<Impg> {
     let index_file = index_file.map(|s| s.to_string());
-    let index_file = index_file.unwrap_or_else(|| format!("{}.impg-lazy", paf_file));
+    let index_file = index_file.unwrap_or_else(|| format!("{}.impg", paf_file));
     let index_file = index_file.as_str();
     if std::path::Path::new(index_file).exists() {
         load_index(index_file)

--- a/src/paf.rs
+++ b/src/paf.rs
@@ -109,7 +109,7 @@ mod tests {
     #[test]
     fn test_parse_paf_valid() {
         let line = "seq1\t100\t0\t100\t+\tseq2\t100\t0\t100\t60\t100\t255";
-        let record = PafRecord::parse(line).unwrap();
+        let record = PafRecord::parse(line, 0).unwrap();
         assert_eq!(
             record,
             PafRecord {
@@ -121,8 +121,11 @@ mod tests {
                 target_length: 100,
                 target_start: 0,
                 target_end: 100,
-                cigar: None, // Adjusted for the example to not include a CIGAR string
                 strand: Strand::Forward,
+                // If no cigar, then the offset is just the length of the line and cigar_bytes=0
+                // Should we use Option<> instead?
+                cigar_offset: (line.len() + 1) as u64,
+                cigar_bytes: 0,
             }
         );
     }
@@ -130,20 +133,20 @@ mod tests {
     #[test]
     fn test_parse_paf_valid_2() {
         let line = "seq1\t100\t0\t100\t+\tseq2\t100\t0\t100\t60\t100\t255\tcg:Z:10=";
-        assert!(PafRecord::parse(line).is_ok());
+        assert!(PafRecord::parse(line, 0).is_ok());
     }
 
     #[test]
     fn test_parse_paf_invalid() {
         // it's got a character 'z' in the length field
         let line = "seq1\t100\t0\t100\t+\tseq2\t100\tz\t100\t60\t100\t255\tcg:Z:10M";
-        assert!(PafRecord::parse(line).is_err());
+        assert!(PafRecord::parse(line, 0).is_err());
     }
 
     #[test]
     fn test_parse_paf_cigar_invalid() {
         // it's got Q in the CIGAR string
         let line = "seq1\t100\t0\t100\t+\tseq2\t100\tz\t100\t60\t100\t255\tcg:Z:10Q";
-        assert!(PafRecord::parse(line).is_err());
+        assert!(PafRecord::parse(line, 0).is_err());
     }
 }


### PR DESCRIPTION
Similar to an `.fai` index, create an `.impg` index which stores the byte offset and byte size of the cigar string (the `cg:Z` tag value), as opposed to storing the entire cigar itself. Then, whenever an record is queried, `impg` looks up the corresponding byte offset/size values, opens the PAF file, seeks the offset, and reads the bytes into a cigar buffer.

TODO:
- [x] Compute byte position/offset from `.gz` files
- [x] Get tests working


# Benchmark
Ran on 23Gb bgzipped PAF file (80 threads for Main and 16 threads for this PR)
```
impg --paf-file test-data/primates16.20231205_wfmash-v0.12.5.paf.bgz --query chm13#1#chr6:28385000-33300000 -x
```
## Main
Index:
```
User time (seconds): 113885.48
System time (seconds): 15729.87
Elapsed (wall clock) time (h:mm:ss or m:ss): 30:59.03
Maximum resident set size (kbytes): 147000032
```

Query:
```
User time (seconds): 53.11
System time (seconds): 14.96
Elapsed (wall clock) time (h:mm:ss or m:ss): 1:08.11
Maximum resident set size (kbytes): 19346680
```

## This PR
Index:
```
User time (seconds): 600.19
System time (seconds): 23.18
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:45.43
Maximum resident set size (kbytes): 272596
```

Query:
```
User time (seconds): 0.65
System time (seconds): 0.08
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:00.74
Maximum resident set size (kbytes): 67592
```