### PR TITLE
Add `bed` input, `bedpe` output, and `paf` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Often, we would like to be able to break a small piece out of a pangenome withou
 
 ## What does `impg` do?
 
-At its core, `impg` lifts over ranges from a target sequence into the other genomes described in alignments.
+At its core, `impg` lifts over ranges from a target sequence (used as reference) into the queries (the other sequences aligned to the sequence used as reference) described in alignments.
 In effect, it lets us pick up homologous loci from all genomes mapped onto our specific target region.
 This is particularly useful when you're interested in comparing a specific genomic region across different individuals, strains, or species in a pangenomic or comparative genomic setting.
-The output is provided in BED format, making it straightforward to use to extract FASTA sequences for downstream use in multiple sequence alignment (like `mafft`) or pangenome graph building (e.g., `pggb` or `minigraph-cactus`).
+The output is provided in BED, BEDPE and PAF formats, making it straightforward to use to extract FASTA sequences for downstream use in multiple sequence alignment (like `mafft`) or pangenome graph building (e.g., `pggb` or `minigraph-cactus`).
 
 ## How does it work?
 
@@ -22,7 +22,7 @@ This approach allows for fast and memory-efficient projection of sequence ranges
 Getting started with `impg` is straightforward. Here's a basic example of how to use the command-line utility:
 
 ```bash
-impg -p cerevisiae.pan.paf.gz -q S288C#1#chrI:50000-100000 -x
+impg -p cerevisiae.pan.paf.gz -r S288C#1#chrI:50000-100000 -x
 ```
 
 Your alignments must use `wfmash` default or `minimap2 --eqx` type CIGAR strings which have `=` for matches and `X` for mismatches. The `M` positional match character is not allowed.
@@ -39,9 +39,9 @@ UWOPS034614#1#chrI  36826  86817
 SK1#1#chrI          52740  102721
 ```
 
-In this example, `-p` specifies the path to the PAF file (compressed with zstd in this case), `-q` defines the query in the format of `target:start-end`, and `-x` requests a *transitive closure* of the matches.
+In this example, `-p` specifies the path to the PAF file, `-r` defines the target range in the format of `seq_name:start-end`, and `-x` requests a *transitive closure* of the matches.
 That is, for each collected range, we then find what sequence ranges are aligned onto it.
-This is done progressively until we've closed the set of alignments connected to the initial query range.
+This is done progressively until we've closed the set of alignments connected to the initial target range.
 
 ### Installation
 

--- a/src/seqidx.rs
+++ b/src/seqidx.rs
@@ -5,6 +5,7 @@ use serde::{Serialize, Deserialize};
 pub struct SequenceIndex {
     name_to_id: HashMap<String, u32>,
     id_to_name: HashMap<u32, String>,
+    id_to_len: HashMap<u32, u64>,
     next_id: u32,
 }
 
@@ -13,17 +14,24 @@ impl SequenceIndex {
         SequenceIndex {
             name_to_id: HashMap::new(),
             id_to_name: HashMap::new(),
+            id_to_len: HashMap::new(),
             next_id: 0,
         }
     }
 
-    pub fn get_or_insert_id(&mut self, name: &str) -> u32 {
-        *self.name_to_id.entry(name.to_owned()).or_insert_with(|| {
+    pub fn get_or_insert_id(&mut self, name: &str, length: Option<u64>) -> u32 {
+        let id = *self.name_to_id.entry(name.to_owned()).or_insert_with(|| {
             let id = self.next_id;
             self.id_to_name.insert(id, name.to_owned());
             self.next_id += 1;
             id
-        })
+        });
+
+        if let Some(len) = length {
+            self.id_to_len.entry(id).or_insert(len);
+        }
+
+        id
     }
 
     pub fn get_id(&self, name: &str) -> Option<u32> {
@@ -32,6 +40,10 @@ impl SequenceIndex {
 
     pub fn get_name(&self, id: u32) -> Option<&str> {
         self.id_to_name.get(&id).map(|s| s.as_str())
+    }
+
+    pub fn get_len_from_id(&self, id: u32) -> Option<u64> {
+        self.id_to_len.get(&id).copied()
     }
 
     pub fn is_empty(&self) -> bool {


### PR DESCRIPTION
```shell
cat x.bed
    S288C#1#chrXII  1000    100000
    S288C#1#chrXII  500000  900000
    S288C#1#chrXII  1000000 2000000
```
```shell
impg -p scerevisiae7.aln.paf -b x.bed | column -t
    S288C#1#chrXII        1000     100000   S288C#1#chrXII  1000     100000
    SK1#1#chrXII          15000    49816    S288C#1#chrXII  1000     100000
    UWOPS034614#1#chrXII  70000    92908    S288C#1#chrXII  1000     100000
    Y12#1#chrXII          90000    104447   S288C#1#chrXII  1000     100000
    S288C#1#chrXII        500000   900000   S288C#1#chrXII  500000   900000
    YPS128#1#chrXII       479121   500000   S288C#1#chrXII  500000   900000
    Y12#1#chrXII          483399   564848   S288C#1#chrXII  500000   900000
    UWOPS034614#1#chrXII  471803   854819   S288C#1#chrXII  500000   900000
    Y12#1#chrXII          585000   780000   S288C#1#chrXII  500000   900000
    YPS128#1#chrXII       590000   790000   S288C#1#chrXII  500000   900000
    SK1#1#chrXII          730000   865468   S288C#1#chrXII  500000   900000
    Y12#1#chrXII          860000   872245   S288C#1#chrXII  500000   900000
    S288C#1#chrXII        1000000  2000000  S288C#1#chrXII  1000000  2000000
    UWOPS034614#1#chrXII  944197   1000000  S288C#1#chrXII  1000000  2000000
    Y12#1#chrXII          980000   1029536  S288C#1#chrXII  1000000  2000000
```