### PR TITLE
Adjust also target ranges and make valid outputs

### DIFF
--- a/src/impg.rs
+++ b/src/impg.rs
@@ -208,15 +208,15 @@ impl Impg {
 
     pub fn query(&self, target_id: u32, range_start: i32, range_end: i32) -> Vec<QueryInterval> {
         let mut results = Vec::new();
-        // add the query interval to the results
-        results.push((
-            Interval {
-                first: range_start,
-                last: range_end,
-                metadata: target_id,
-            },
-            vec![CigarOp::new(range_end - range_start, '=')],
-        ));
+        // // add the input target interval to the results
+        // results.push((
+        //     Interval {
+        //         first: range_start,
+        //         last: range_end,
+        //         metadata: target_id,
+        //     },
+        //     vec![CigarOp::new(range_end - range_start, '=')],
+        // ));
         if let Some(tree) = self.trees.get(&target_id) {
             tree.query(range_start, range_end, |interval| {
                 let metadata = &interval.metadata;
@@ -242,15 +242,15 @@ impl Impg {
 
     pub fn query_transitive(&self, target_id: u32, range_start: i32, range_end: i32) -> Vec<QueryInterval> {
         let mut results = Vec::new();
-        // add the query interval to the results
-        results.push((
-            Interval {
-                first: range_start,
-                last: range_end,
-                metadata: target_id,
-            },
-            vec![CigarOp::new(range_end - range_start, '=')]
-        ));
+        // // add the input target interval to the results
+        // results.push((
+        //     Interval {
+        //         first: range_start,
+        //         last: range_end,
+        //         metadata: target_id,
+        //     },
+        //     vec![CigarOp::new(range_end - range_start, '=')]
+        // ));
         let mut stack = vec![(target_id, range_start, range_end)];
         let mut visited = HashSet::new();
 
@@ -308,7 +308,7 @@ fn project_target_range_through_alignment(
             break;
         }
         match (cigar_op.target_delta(), cigar_op.query_delta(strand)) {
-            (0, query_delta) => { // Insertion in query
+            (0, query_delta) => { // Insertion in query (deletions in target)
                 if target_pos >= target_range.0 && target_pos <= target_range.1 {
                     projected_start.get_or_insert(query_pos);
                     projected_end = Some(query_pos +
@@ -317,7 +317,7 @@ fn project_target_range_through_alignment(
                 }
                 query_pos += query_delta;
             },
-            (target_delta, 0) => { // Deletion in target
+            (target_delta, 0) => { // Deletion in query (insertions in target)
                 let overlap_start = target_pos.max(target_range.0);
                 let overlap_end = (target_pos + target_delta).min(target_range.1);
 

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -291,7 +291,7 @@ impl Impg {
 fn project_target_range_through_alignment(
     target_range: (i32, i32),
     record: (i32, i32, i32, i32, Strand),
-    cigar_ops: &[CigarOp],
+    cigar_ops: &[CigarOp]
 ) -> (i32, i32, Vec<CigarOp>) {
     let (target_start, _target_end, query_start, query_end, strand) = record;
 

--- a/src/impg.rs
+++ b/src/impg.rs
@@ -131,8 +131,8 @@ impl Impg {
 
         let mut seq_index = SequenceIndex::new();
         for record in records {
-            seq_index.get_or_insert_id(&record.query_name, Some(record.target_length as u64));
-            seq_index.get_or_insert_id(&record.target_name, Some(record.target_length as u64));
+            seq_index.get_or_insert_id(&record.query_name, Some(record.target_length));
+            seq_index.get_or_insert_id(&record.target_name, Some(record.target_length));
         }
         
         let intervals: HashMap<u32, Vec<Interval<QueryMetadata>>> = records.par_iter()
@@ -261,7 +261,7 @@ impl Impg {
                     let (adjusted_start, adjusted_end, adjusted_cigar) = project_target_range_through_alignment(
                         (current_start, current_end),
                         (metadata.target_start, metadata.target_end, metadata.query_start, metadata.query_end, metadata.strand),
-                    &metadata.get_cigar_ops(&self.paf_file, self.paf_gzi_index.as_ref())
+                        &metadata.get_cigar_ops(&self.paf_file, self.paf_gzi_index.as_ref())
                     );
 
                     let adjusted_interval = (

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,43 +188,43 @@ fn perform_query(impg: &Impg, target_name: &str, target_range: (i32, i32), trans
 }
 
 fn output_results_bed(impg: &Impg, results: Vec<AdjustedInterval>) {
-    for (overlap, _, _) in results {
-        let overlap_name = impg.seq_index.get_name(overlap.metadata).unwrap();
-        let (first, last, strand) = if overlap.first <= overlap.last {
-            (overlap.first, overlap.last, '+')
+    for (query_id, (overlap_query_start, overlap_query_end), _, _, (alignment_query_end, _)) in results {
+        let overlap_name = impg.seq_index.get_name(query_id).unwrap();
+        let (first, last, strand) = if overlap_query_start <= overlap_query_end {
+            (overlap_query_start, overlap_query_end, '+')
         } else {
-            (overlap.last, overlap.first, '-')
+            (overlap_query_end, overlap_query_start, '-')
         };
-        println!("{}\t{}\t{}\t.\t{}", overlap_name, first, last, strand);
+        println!("{}\t{}\t{}\t.\t{}", overlap_name, first, (last + 1).min(alignment_query_end), strand);
     }
 }
 
 fn output_results_bedpe(impg: &Impg, results: Vec<AdjustedInterval>, target_name: &str, name: Option<String>) {
-    for (overlap_query, _, overlap_target) in results {
-        let overlap_name = impg.seq_index.get_name(overlap_query.metadata).unwrap();
-        let (first, last, strand) = if overlap_query.first <= overlap_query.last {
-            (overlap_query.first, overlap_query.last, '+')
+    for (query_id, (overlap_query_start, overlap_query_end), _, (overlap_target_start, overlap_target_end), (alignment_query_end, alignment_target_end)) in results {
+        let overlap_name = impg.seq_index.get_name(query_id).unwrap();
+        let (first, last, strand) = if overlap_query_start <= overlap_query_end {
+            (overlap_query_start, overlap_query_end, '+')
         } else {
-            (overlap_query.last, overlap_query.first, '-')
+            (overlap_query_end, overlap_query_start, '-')
         };
         println!("{}\t{}\t{}\t{}\t{}\t{}\t{}\t0\t{}\t+",
-                 overlap_name, first, last,
-                 target_name, overlap_target.first, overlap_target.last,
+                 overlap_name, first, (last + 1).min(alignment_query_end),
+                 target_name, overlap_target_start, (overlap_target_end + 1).min(alignment_target_end),
                  name.as_deref().unwrap_or("."), strand);
     }
 }
 
 fn output_results_paf(impg: &Impg, results: Vec<AdjustedInterval>, target_name: &str, name: Option<String>) { 
     let target_length = impg.seq_index.get_len_from_id(impg.seq_index.get_id(target_name).unwrap()).unwrap();  
-    for (overlap_query, cigar, overlap_target) in results {
-        let overlap_name = impg.seq_index.get_name(overlap_query.metadata).unwrap();
-        let (first, last, strand) = if overlap_query.first <= overlap_query.last {
-            (overlap_query.first, overlap_query.last, '+')
+    for (query_id, (overlap_query_start, overlap_query_end), cigar, (overlap_target_start, overlap_target_end), (alignment_query_end, alignment_target_end)) in results {
+        let overlap_name = impg.seq_index.get_name(query_id).unwrap();
+        let (first, last, strand) = if overlap_query_start <= overlap_query_end {
+            (overlap_query_start, overlap_query_end, '+')
         } else {
-            (overlap_query.last, overlap_query.first, '-')
+            (overlap_query_end, overlap_query_start, '-')
         };
 
-        let query_length = impg.seq_index.get_len_from_id(overlap_query.metadata).unwrap();  
+        let query_length = impg.seq_index.get_len_from_id(query_id).unwrap();  
 
         let has_m_operation = cigar.iter().any(|op| op.op() == 'M');
         let (matches, block_len) = if has_m_operation {
@@ -252,12 +252,12 @@ fn output_results_paf(impg: &Impg, results: Vec<AdjustedInterval>, target_name: 
 
         match name {
             Some(ref name) => println!("{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\tcg:Z:{}\tan:Z:{}",
-                                    overlap_name, query_length, first, last, strand,
-                                    target_name, target_length, overlap_target.first, overlap_target.last,
+                                    overlap_name, query_length, first, (last + 1).min(alignment_query_end), strand,
+                                    target_name, target_length, overlap_target_start, (overlap_target_end + 1).min(alignment_target_end),
                                     matches, block_len, 255, cigar_str, name),
             None => println!("{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\tcg:Z:{}",
-                                overlap_name, query_length, first, last, strand,
-                                target_name, target_length, overlap_target.first, overlap_target.last,
+                                overlap_name, query_length, first, (last + 1).min(alignment_query_end), strand,
+                                target_name, target_length, overlap_target_start, (overlap_target_end + 1).min(alignment_target_end),
                                 matches, block_len, 255, cigar_str),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,7 +256,7 @@ fn output_results_paf(impg: &Impg, results: Vec<QueryInterval>, target_name: &st
                                     target_name, target_length, target_range.0, target_range.1,
                                     matches, block_len, 255, cigar_str, name),
             None => println!("{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\tcg:Z:{}",
-                                overlap_name, query_length, overlap.first, overlap.last, strand,
+                                overlap_name, query_length, first, last, strand,
                                 target_name, target_length, target_range.0, target_range.1,
                                 matches, block_len, 255, cigar_str),
         }

--- a/src/seqidx.rs
+++ b/src/seqidx.rs
@@ -5,7 +5,7 @@ use serde::{Serialize, Deserialize};
 pub struct SequenceIndex {
     name_to_id: HashMap<String, u32>,
     id_to_name: HashMap<u32, String>,
-    id_to_len: HashMap<u32, u64>,
+    id_to_len: HashMap<u32, usize>,
     next_id: u32,
 }
 
@@ -19,7 +19,7 @@ impl SequenceIndex {
         }
     }
 
-    pub fn get_or_insert_id(&mut self, name: &str, length: Option<u64>) -> u32 {
+    pub fn get_or_insert_id(&mut self, name: &str, length: Option<usize>) -> u32 {
         let id = *self.name_to_id.entry(name.to_owned()).or_insert_with(|| {
             let id = self.next_id;
             self.id_to_name.insert(id, name.to_owned());
@@ -42,7 +42,7 @@ impl SequenceIndex {
         self.id_to_name.get(&id).map(|s| s.as_str())
     }
 
-    pub fn get_len_from_id(&self, id: u32) -> Option<u64> {
+    pub fn get_len_from_id(&self, id: u32) -> Option<usize> {
         self.id_to_len.get(&id).copied()
     }
 


### PR DESCRIPTION
With this PR, now we:
- also adjust target ranges (not only query ranges)
- emit valid BEDPE and PAF outputs
- remove the input from the output
- fix a few bugs.